### PR TITLE
switch everything to be a JupyterApp accessible via jupyter-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,17 @@
-In order to use this 
+In order to use this
 
-    pip install jupyter_conf_search 
+    pip install jupyter_config
 
-Which is then executed as 
+Which is then executed as
 
-    jupyter_conf_search "your_search_term"
+    jupyter config "your_search_term"
 
 on the command line to search for "`your_search_term`".
 
-If you pass just 
+If you pass just
 
-    jupyter_conf_search
+    jupyter config
 
 it will return the total list of configuration files that it found relative to
 the directory that you are running the command from (not just the directories,
-which you can find using `jupyter --paths` beneath `config:`). 
-
-© M Pacer 
+which you can find using `jupyter --paths` beneath `config:`).

--- a/flit.ini
+++ b/flit.ini
@@ -1,5 +1,5 @@
 [metadata]
-module = jupyter_conf_search
+module = jupyter_config
 author = mpacer
 author-email = mpacer@berkeley.edu
 home-page = https://github.com/mpacer/jupyter_conf_search
@@ -9,4 +9,4 @@ description-file = README.md
 
 
 [scripts]
-jupyter_conf_search = jupyter_conf_search:main
+jupyter-config = jupyter_config.configapp:main

--- a/jupyter_conf_search/__main__.py
+++ b/jupyter_conf_search/__main__.py
@@ -1,3 +1,0 @@
-from .jupyter_conf_search import main 
-
-main()

--- a/jupyter_config/__init__.py
+++ b/jupyter_config/__init__.py
@@ -1,8 +1,3 @@
 """Utility for searching through jupyter configuration files, using jupyter's path definitions to find their locations dynamically.
 
 """
-
-__version__="0.4.4"
-
-from .jupyter_conf_search import main
-

--- a/jupyter_config/__main__.py
+++ b/jupyter_config/__main__.py
@@ -1,0 +1,3 @@
+from .configapp import main 
+
+main()

--- a/jupyter_config/_version.py
+++ b/jupyter_config/_version.py
@@ -1,0 +1,63 @@
+version_info = (0, 4, 5)
+pre_info = ''
+dev_info = 'dev'
+
+def create_valid_version(release_info, epoch=None, pre_input='', dev_input=''):
+    '''
+    Creates a pep440 valid version of version number given a tuple integers 
+    and optional epoch, prerelease and developmental info. 
+
+    Parameters
+    ----------
+    release_info : Tuple(Int)
+    epoch : Int, default None
+    pre_input : Str, default ''
+    dev_input : Str, default ''
+    '''
+
+    pep440_err = "The version number is not a pep 440 compliant version number"
+    
+    
+    if epoch is not None:
+        epoch_seg = str(epoch) + '!'
+    else:
+        epoch_seg = ''
+
+    release_seg = '.'.join(map(str, release_info))
+
+    _magic_pre =  ['a','b','rc']
+    if pre_input!='' and not any([pre_input.startswith(prefix) for prefix in _magic_pre]):
+        raise ValueError(pep440_err + "\n please fix your prerelease segment.")
+    else:
+        pre_seg = pre_input
+    
+    if dev_input=='':
+        dev_seg = dev_input
+    elif not dev_input.startswith('.') and dev_input.startswith('dev'):
+        dev_seg = ''.join(['.', dev_input])
+    elif dev_input.startswith('.dev'):
+        dev_seg = dev_input
+    elif dev_input!='':
+        raise ValueError(pep440_err + "\n please fix your development segment.")
+    
+    if dev_input!='' and not any([dev_seg.endswith(str(n)) for n in range(10)]):
+        dev_seg = ''.join([dev_seg,'0'])
+
+    out_version = ''.join([epoch_seg, release_seg, pre_seg, dev_seg])
+
+
+    import re
+    def is_canonical(version):
+        return re.match(r'^([1-9]\d*!)?(0|[1-9]\d*)'
+                        r'(\.(0|[1-9]\d*))*((a|b|rc)(0|[1-9]\d*))?'
+                        r'(\.post(0|[1-9]\d*))?(\.dev(0|[1-9]\d*))?$', 
+                        version
+                        ) is not None
+    
+    if is_canonical(out_version):
+        return out_version
+    else:
+        raise ValueError(pep440_err)
+
+
+__version__ = create_valid_version(version_info, pre_input=pre_info, dev_input=dev_info) 

--- a/jupyter_config/configapp.py
+++ b/jupyter_config/configapp.py
@@ -1,8 +1,50 @@
-import jupyter_core.paths as jpaths
 import glob
 import os
 import sys
-import re
+import re 
+
+from jupyter_core.application import JupyterApp, base_aliases, base_flags
+import jupyter_core.paths as jpaths
+from traitlets.config import catch_config_error
+
+config_aliases = {}
+config_aliases.update(base_aliases)
+
+config_flags = {}
+config_flags.update(base_flags)
+
+class JupyterConfigApp(JupyterApp):
+    name = "jupyter-config"
+    description = "A Jupyter Application for searching in and finding config files."
+    # aliases = config_aliases
+    # flags = config_flags
+    
+    
+    # subcommands = dict(
+    #     list=(JupyterConfigListApp, JupyterConfigListApp.description.splitlines()[0]),
+    #     search=(JupyterConfigSearchApp, JupyterConfigSearchApp.description.splitlines()[0]),
+    # )
+    
+    @catch_config_error
+    def initialize(self, argv=None):
+        super(JupyterConfigApp, self).initialize(argv)
+        search_jupyter_paths(self.extra_args)
+        
+    # @classmethod
+    # def launch_instance(cls, argv=None, **kwargs):
+    #     import ipdb; ipdb.set_trace()
+    #     super(JupyterConfigApp, cls).launch_instance(argv=argv, **kwargs)
+        
+    
+    
+    # @classmethod
+    # def main(cls):
+    #     if len(sys.argv)==1:
+    #         search_jupyter_paths()
+    #     elif len(sys.argv)==2:
+    #         search_jupyter_paths(sys.argv[1])
+    #     else:
+    #         raise RuntimeError("You can only pass in a single string at this time.")
 
 def valid_conf_file(file_name):
 # replace with canonical config validation checker
@@ -22,6 +64,10 @@ def valid_local_conf_file(file_path):
     
 def search_jupyter_paths(search_term=''):
     
+    if search_term is not '' and isinstance(search_term, list) and len(search_term)>0:
+        search_term = search_term[0]
+         
+    # print(search_term)
     conf_path_list = []
     for dir in jpaths.jupyter_config_path():
         conf_path_list.extend(glob.glob(dir+"/**", recursive=True))
@@ -31,9 +77,9 @@ def search_jupyter_paths(search_term=''):
     
     conf_file_list.extend([f for f in local_path_list if valid_local_conf_file(f)])
     
-    # go through files, 
+    # go through files,
     # if search term found in file
-    # print name, line_no, content 
+    # print name, line_no, content
     conf_file_list.reverse()
     for file_name in conf_file_list:
         if len(search_term)>0:
@@ -52,13 +98,5 @@ def print_indexed_content(file_name='', search_term=''):
             output = ["{}: {}".format(x,y) for x,y in line_numbers_match]
             print(file_name + "\n" + "\n".join(output),"\n")
 
-def main():
-    if len(sys.argv)==1:
-        search_jupyter_paths()
-    elif len(sys.argv)==2:
-        search_jupyter_paths(sys.argv[1])
-    else:
-        raise RuntimeError("You can only pass in a single string at this time.")
 
-if __name__ == "__main__":
-    main()
+main = launch_new_instance = JupyterConfigApp.launch_instance

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,25 @@
 from setuptools import setup
-from jupyter_conf_search import __version__
+import os
 
+here = os.path.abspath(os.path.dirname(__file__))
+name = 'jupyter_config'
+
+version_ns = {}
+with open(os.path.join(here, name, '_version.py')) as f:
+    exec(f.read(), {}, version_ns)
 
 setup(
-    name='jupyter_conf_search',
-    packages=['jupyter_conf_search'],
-    version=__version__,
+    name='jupyter_config',
+    packages=['jupyter_config'],
+    version=version_ns['__version__'],
     author='M Pacer',
     author_email='mpacer@berkeley.edu',
-    url='https://github.com/mpacer/jupyter_conf_search',
+    url='https://github.com/mpacer/jupyter_config',
     install_requires=[
-        "jupyter"
-        ]
+        "jupyter_core"
+        ],
+    entry_points={
+        'console_scripts':[
+            'jupyter-config = jupyter_config.configapp:main'
+        ]}
 )


### PR DESCRIPTION
This leaves `jupyter_conf_search` behind but keeps its api. 

I think we'll want a new CLI for 1.0.