### PR TITLE
update requirements to include notebook to account for nbconfig stuff

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ setup(
     author_email='mpacer@berkeley.edu',
     url='https://github.com/mpacer/jupyter_config',
     install_requires=[
-        "jupyter_core"
+        "jupyter_core",
+        "notebook>=5.3"
         ],
     entry_points={
         'console_scripts':[


### PR DESCRIPTION
Right now this doesn't install everything it needs.

I would like it to not require notebook, but it's hard to write the nbconfig and confd code without relying on notebook for the canonical reference.